### PR TITLE
Add a first jasmine-test

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-prettier": "^3.1.3",
     "jasmine": "^3.5.0",
+    "jsdom": "^16.2.2",
     "prettier": "^2.0.5"
   }
 }

--- a/scriptByClass.js
+++ b/scriptByClass.js
@@ -132,3 +132,5 @@ calculatorDOM.addEventListener('click', (e) => {
 // const str = '74 * 654 - 5896/6541 + 985.5 + 6 * 9'
 
 // console.log(Calc.calculate(str))
+
+module.exports = Calculator

--- a/spec/scriptByClass.spec.js
+++ b/spec/scriptByClass.spec.js
@@ -1,0 +1,36 @@
+const { JSDOM } = require('jsdom');
+
+const jsdom = new JSDOM(`
+  <!DOCTYPE html>
+  <html>
+    <body>
+      <div id="calculator">
+        <div id="viewer" class="viewer">0</div>
+
+        <button class="ops" data-data="+" data-action="operator">+</button>
+
+        <button class="num" data-data="1" data-action="number">1</button>
+        <button class="num" data-data="3" data-action="number">3</button>
+
+        <button class="equals ops" data-data="=" data-action="equals" id="equals">=</button>
+      </div>
+    </body>
+  </html>
+`);
+
+global.document = jsdom.window.document;
+
+const Calculator = require('../scriptByClass')
+
+describe('Calculator', () => {
+  it('shows “4” in viewer after clicking on “1 + 3 =”', () => {
+    const calculator = new Calculator();
+
+    document.querySelector('[data-data="1"]').click();
+    document.querySelector('[data-data="+"]').click();
+    document.querySelector('[data-data="3"]').click();
+    document.querySelector('[data-data="="]').click();
+
+    expect(document.getElementById('viewer').innerText).toBe('4');
+  });
+});


### PR DESCRIPTION
Hey! :wave: In this PR, I added a first test. I only added what was necessary for that test to run, for more tests you’d have to complete the setup a little. Run `npm run test` to see the one test pass.

This only tests the `Calculator`-class. To make it available, I had to export it from `scriptByClass.js`. It’s imported in `spec/scriptByClass.spec.js`.

Because the calculator relies on DOM-elements in a `document`, we use JSDOM to provide those during a test run. I had to add `jsdom` to the `devDependencies`.

We give that simulated DOM in the spec-file a markup that is similar to the one in `index.html`. In the test, we click on the elements that correspond to the buttons for the calculation “1 + 3 =” before checking that the viewer says “4”.

Maybe you can use this as a baseline for your other tests!